### PR TITLE
fix: separate OkHttpClient for glide

### DIFF
--- a/api/src/main/java/com/readrops/api/ApiModule.kt
+++ b/api/src/main/java/com/readrops/api/ApiModule.kt
@@ -38,6 +38,14 @@ val apiModule = module {
                 .build()
     }
 
+    single(createdAtStart = true, qualifier = named("forGlide")) {
+        OkHttpClient.Builder()
+                .callTimeout(1, TimeUnit.MINUTES)
+                .readTimeout(1, TimeUnit.HOURS)
+                .addInterceptor(NiddlerOkHttpInterceptor(get(), "niddler"))
+                .build()
+    }
+
     single { AuthInterceptor() }
 
     single { LocalRSSDataSource(get()) }

--- a/app/src/main/java/com/readrops/app/utils/ReadropsGlideModule.kt
+++ b/app/src/main/java/com/readrops/app/utils/ReadropsGlideModule.kt
@@ -10,13 +10,14 @@ import com.bumptech.glide.module.AppGlideModule
 import okhttp3.OkHttpClient
 import org.koin.core.KoinComponent
 import org.koin.core.get
+import org.koin.core.qualifier.named
 import java.io.InputStream
 
 @GlideModule
 class ReadropsGlideModule : AppGlideModule(), KoinComponent {
 
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
-        val factory = OkHttpUrlLoader.Factory(get<OkHttpClient>())
+        val factory = OkHttpUrlLoader.Factory(get<OkHttpClient>(named("forGlide")))
 
         glide.registry.replace(GlideUrl::class.java, InputStream::class.java, factory)
     }


### PR DESCRIPTION
Sometimes glide requests for feed icon with a wrong URL `https://base-url-of-rss-account/path/to/icon` instead of `https://host-of-icon/path/to/icon` because `AuthInterceptor` has an incorrect state.

Using a separate `OkHttpClient` for glide could be better.