### PR TITLE
fix: set updating to false when refresh failed

### DIFF
--- a/app/src/main/java/com/readrops/app/itemslist/MainActivity.java
+++ b/app/src/main/java/com/readrops/app/itemslist/MainActivity.java
@@ -619,6 +619,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
 
                         Utils.showSnackbar(binding.mainRoot, e.getMessage());
                         drawerManager.enableAccountSelection();
+                        updating = false;
                     }
 
                     @Override


### PR DESCRIPTION
If not, UI state will be inconsistent when `sync` fails.