### PR TITLE
Make system navigation bar color match the app background

### DIFF
--- a/app/src/main/res/values-night-v27/styles.xml
+++ b/app/src/main/res/values-night-v27/styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <style name="AppTheme" parent="MaterialDrawerTheme.ActionBar">
@@ -12,10 +13,8 @@
 
         <item name="bottomSheetDialogTheme">@style/Theme.Design.BottomSheetDialog</item>
         <item name="buttonStyle">@style/GenericButton</item>
-    </style>
 
-    <style name="GenericButton" parent="Widget.AppCompat.Button.Colored">
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:navigationBarColor">@color/colorBackgroundDark</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
-
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="MaterialDrawerTheme.Light.ActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:colorBackground">@color/colorBackground</item>
+        <item name="colorControlNormal">@color/colorControlNormal</item>
+        <item name="android:textColorPrimary">@color/textColorPrimary</item>
+
+        <item name="actionModeBackground">@color/colorPrimary</item>
+        <item name="actionBarTheme">@style/ToolbarTheme</item>
+        <item name="android:navigationBarColor">@color/colorBackground</item>
+        <item name="android:windowLightNavigationBar">true</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+    </style>
+
+    <style name="SplashTheme" parent="AppTheme.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+        <item name="android:navigationBarColor">@color/colorPrimaryDark</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,5 +5,6 @@
     <color name="colorAccent">#19A3FF</color>
     <color name="colorControlNormal">#d7d7d7</color>
     <color name="colorBackground">#fafafa</color>
+    <color name="colorBackgroundDark">#2e2e2e</color>
     <color name="textColorPrimary">#000000</color>
 </resources>


### PR DESCRIPTION
This makes the navigation bar color blend with the content background color in Android 27+

Splash page
![image](https://user-images.githubusercontent.com/10982418/130338398-71148875-5e75-4320-a969-c18c3b483429.png)

Setup page
![image](https://user-images.githubusercontent.com/10982418/130338411-dd8cd021-c367-4b24-9e46-0808bf4295ce.png)

Article list (light)
![image](https://user-images.githubusercontent.com/10982418/130338418-8fb85d25-0b73-4d30-a96e-2ddd2f2ea021.png)

Content view (light)
![image](https://user-images.githubusercontent.com/10982418/130338421-972ed20d-3865-4004-81e1-e544572e1797.png)

Article list (dark)
![image](https://user-images.githubusercontent.com/10982418/130338428-70cea61b-6f20-4e8c-abf3-7175491a4224.png)

Content view (dark)
![image](https://user-images.githubusercontent.com/10982418/130338430-7fab8357-5fbc-4d09-93d9-94f79fced50e.png)

