### PR TITLE
Fix import opml without folders.

### DIFF
--- a/db/src/main/java/com/readrops/db/pojo/FeedWithFolder.kt
+++ b/db/src/main/java/com/readrops/db/pojo/FeedWithFolder.kt
@@ -9,5 +9,5 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class FeedWithFolder(
         @Embedded(prefix = "feed_") val feed: Feed,
-        @Embedded(prefix = "folder_") val folder: Folder,
+        @Embedded(prefix = "folder_") val folder: Folder?,
 ) : Parcelable


### PR DESCRIPTION
When OPML doesn't contain folders (all feeds are located in root) app can't import it.
I've fixed it.

For reproducing try to import this OPML:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<opml version="2.0">
<head>
<title>Feed Subscriptions</title>
</head>
<body>
      <outline text="The Kotlin Blog" title="The Kotlin Blog" type="rss"
            xmlUrl="https://blog.jetbrains.com/kotlin/feed/" htmlUrl="https://blog.jetbrains.com"/>
</body>
</opml>
```