### PR TITLE
Fix error in case that Nextcloud News item does not have a body element

### DIFF
--- a/app/src/main/java/com/readrops/app/repositories/NextNewsRepository.java
+++ b/app/src/main/java/com/readrops/app/repositories/NextNewsRepository.java
@@ -337,7 +337,9 @@ public class NextNewsRepository extends ARepository {
             }
 
             item.setFeedId(feedId);
-            item.setReadTime(Utils.readTimeFromString(item.getContent()));
+
+            if (item.getText() != null)
+                item.setReadTime(Utils.readTimeFromString(item.getText()));
 
             itemsToInsert.add(item);
         }


### PR DESCRIPTION
When using Readrops to fetch news items from Nextcloud 24.0.6 with News Plugin 18.2.0, it is possible that a news item may not contain a "body" element. In this case, the "content" member of the corresponding item instance will be null, causing the computation of the read time during the initial sync to fail. The change in this pull request causes Readrops to use the description property of the corresponding item instead if it is available or just leaving the default value of 0.0 for the read time if neither the content nor the description is set. 