### PR TITLE
Suppress error due to type variables for setReadState and setStarState

### DIFF
--- a/api/src/main/java/com/readrops/api/services/nextcloudnews/NextNewsDataSource.java
+++ b/api/src/main/java/com/readrops/api/services/nextcloudnews/NextNewsDataSource.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import kotlin.jvm.JvmSuppressWildcards;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import retrofit2.Response;

--- a/api/src/main/java/com/readrops/api/services/nextcloudnews/NextNewsService.kt
+++ b/api/src/main/java/com/readrops/api/services/nextcloudnews/NextNewsService.kt
@@ -26,9 +26,11 @@ interface NextNewsService {
     fun getNewItems(@Query("lastModified") lastModified: Long, @Query("type") type: Int): Call<List<Item>>
 
     @PUT("items/{stateType}/multiple")
+    @JvmSuppressWildcards
     fun setReadState(@Path("stateType") stateType: String, @Body itemIdsMap: Map<String, List<String>>): Call<ResponseBody>
 
     @PUT("items/{starType}/multiple")
+    @JvmSuppressWildcards
     fun setStarState(@Path("starType") starType: String?, @Body body: Map<String?, List<Map<String, String>>>): Call<ResponseBody>
 
     @POST("feeds")


### PR DESCRIPTION
When changing the read state or star state of a Nextcloud News item, an error situation similar to the one described in [Retrofit Issue 2457](https://github.com/square/retrofit/issues/2457) occurs. The changes in this pull request reflect the advice given in the previously mentioned issue. 