### PR TITLE
Fix endoint slash

### DIFF
--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -5,6 +5,7 @@ import com.readrops.api.services.freshrss.FreshRSSCredentials
 import com.readrops.api.services.freshrss.FreshRSSService
 import com.readrops.api.services.nextcloudnews.NextcloudNewsCredentials
 import com.readrops.api.services.nextcloudnews.NextcloudNewsService
+import com.readrops.api.utils.Utils
 import com.readrops.db.entities.account.Account
 import com.readrops.db.entities.account.AccountType
 
@@ -12,12 +13,13 @@ abstract class Credentials(val authorization: String?, val url: String) {
 
     companion object {
         fun toCredentials(account: Account): Credentials {
-            val endPoint = getEndPoint(account.type!!)
+            val endPoint = getEndPoint(account.type!!).removePrefix("/")
+            var accountUrl = Utils.normalizeUrl(account.url)
 
             return when (account.type) {
-                AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, account.url + endPoint)
-                AccountType.FRESHRSS -> FreshRSSCredentials(account.token, account.url + endPoint)
-                AccountType.FEVER -> FeverCredentials(account.login, account.password, account.url + endPoint)
+                AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, accountUrl + endPoint)
+                AccountType.FRESHRSS -> FreshRSSCredentials(account.token, accountUrl + endPoint)
+                AccountType.FEVER -> FeverCredentials(account.login, account.password, accountUrl + endPoint)
                 else -> throw IllegalArgumentException("Unknown account type")
             }
         }

--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -13,7 +13,7 @@ abstract class Credentials(val authorization: String?, val url: String) {
     companion object {
         fun toCredentials(account: Account): Credentials {
             val endPoint = getEndPoint(account.type!!).removePrefix("/")
-            var accountUrl = account.url
+            var accountUrl = account.url!!
             if (!accountUrl.endsWith("/")) {
                 accountUrl += "/"
             }

--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -5,7 +5,6 @@ import com.readrops.api.services.freshrss.FreshRSSCredentials
 import com.readrops.api.services.freshrss.FreshRSSService
 import com.readrops.api.services.nextcloudnews.NextcloudNewsCredentials
 import com.readrops.api.services.nextcloudnews.NextcloudNewsService
-import com.readrops.app.util.Utils
 import com.readrops.db.entities.account.Account
 import com.readrops.db.entities.account.AccountType
 
@@ -14,7 +13,10 @@ abstract class Credentials(val authorization: String?, val url: String) {
     companion object {
         fun toCredentials(account: Account): Credentials {
             val endPoint = getEndPoint(account.type!!).removePrefix("/")
-            var accountUrl = Utils.normalizeUrl(account.url)
+            var accountUrl = account.url
+            if (!accountUrl.endsWith("/")) {
+                accountUrl += "/"
+            }
 
             return when (account.type) {
                 AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, accountUrl + endPoint)

--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -5,7 +5,7 @@ import com.readrops.api.services.freshrss.FreshRSSCredentials
 import com.readrops.api.services.freshrss.FreshRSSService
 import com.readrops.api.services.nextcloudnews.NextcloudNewsCredentials
 import com.readrops.api.services.nextcloudnews.NextcloudNewsService
-import com.readrops.api.utils.Utils
+import com.readrops.app.util.Utils
 import com.readrops.db.entities.account.Account
 import com.readrops.db.entities.account.AccountType
 

--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -13,15 +13,11 @@ abstract class Credentials(val authorization: String?, val url: String) {
     companion object {
         fun toCredentials(account: Account): Credentials {
             val endPoint = getEndPoint(account.type!!).removePrefix("/")
-            var accountUrl = account.url!!
-            if (!accountUrl.endsWith("/")) {
-                accountUrl += "/"
-            }
 
             return when (account.type) {
-                AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, accountUrl + endPoint)
-                AccountType.FRESHRSS -> FreshRSSCredentials(account.token, accountUrl + endPoint)
-                AccountType.FEVER -> FeverCredentials(account.login, account.password, accountUrl + endPoint)
+                AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, account.url + endPoint)
+                AccountType.FRESHRSS -> FreshRSSCredentials(account.token, account.url + endPoint)
+                AccountType.FEVER -> FeverCredentials(account.login, account.password, account.url + endPoint)
                 else -> throw IllegalArgumentException("Unknown account type")
             }
         }

--- a/api/src/main/java/com/readrops/api/services/Credentials.kt
+++ b/api/src/main/java/com/readrops/api/services/Credentials.kt
@@ -12,7 +12,7 @@ abstract class Credentials(val authorization: String?, val url: String) {
 
     companion object {
         fun toCredentials(account: Account): Credentials {
-            val endPoint = getEndPoint(account.type!!).removePrefix("/")
+            val endPoint = getEndPoint(account.type!!)
 
             return when (account.type) {
                 AccountType.NEXTCLOUD_NEWS -> NextcloudNewsCredentials(account.login, account.password, account.url + endPoint)

--- a/api/src/main/java/com/readrops/api/services/fever/FeverService.kt
+++ b/api/src/main/java/com/readrops/api/services/fever/FeverService.kt
@@ -39,7 +39,7 @@ interface FeverService {
                                 @Query("id") id: String)
 
     companion object {
-        const val END_POINT = "/api/fever.php/"
+        const val END_POINT = "api/fever.php/"
     }
 
 }

--- a/api/src/main/java/com/readrops/api/services/freshrss/FreshRSSService.kt
+++ b/api/src/main/java/com/readrops/api/services/freshrss/FreshRSSService.kt
@@ -92,6 +92,6 @@ interface FreshRSSService {
     suspend fun deleteFolder(@Field("T") token: String, @Field("s") folderId: String)
 
     companion object {
-        const val END_POINT = "/api/greader.php/"
+        const val END_POINT = "api/greader.php/"
     }
 }

--- a/api/src/main/java/com/readrops/api/services/nextcloudnews/NextcloudNewsService.kt
+++ b/api/src/main/java/com/readrops/api/services/nextcloudnews/NextcloudNewsService.kt
@@ -68,6 +68,6 @@ interface NextcloudNewsService {
     suspend fun renameFolder(@Path("folderId") folderId: Int, @Body folderName: Map<String, String>)
 
     companion object {
-        const val END_POINT = "/index.php/apps/news/api/v1-3/"
+        const val END_POINT = "index.php/apps/news/api/v1-3/"
     }
 }


### PR DESCRIPTION
The URLs sent to the API contained a slash too much:

Example for FreshRSS:

```
"POST //api/greader.php/reader/api/0/edit-tag HTTP/1.1" 200 2 "-" "okhttp/4.12.0"

"GET //api/greader.php/reader/api/0/tag/list?output=json HTTP/1.1" 200 654 "-" "okhttp/4.12.0"
```
