### PR TITLE
UX: change read and unread icons to match FreshRSS'

### DIFF
--- a/app/src/main/java/com/readrops/app/item/components/ItemScreenBottomBar.kt
+++ b/app/src/main/java/com/readrops/app/item/components/ItemScreenBottomBar.kt
@@ -54,9 +54,11 @@ fun ItemScreenBottomBar(
             ) {
                 Icon(
                     painter = painterResource(
-                        id = if (state.isRead)
-                            R.drawable.ic_remove_done
-                        else R.drawable.ic_done_all
+                        id = if (state.isRead) {
+                            R.drawable.ic_state_read
+                        } else {
+                            R.drawable.ic_state_unread
+                        }
                     ),
                     tint = onAccentColor,
                     contentDescription = null

--- a/app/src/main/java/com/readrops/app/timelime/components/TimelineItem.kt
+++ b/app/src/main/java/com/readrops/app/timelime/components/TimelineItem.kt
@@ -81,9 +81,9 @@ fun TimelineItem(
     fun getSwipeIcon(swipeAction: SwipeAction): Int {
         return if (swipeAction == SwipeAction.READ) {
             if (itemWithFeed.isRead) {
-                R.drawable.ic_remove_done
+                R.drawable.ic_state_unread
             } else {
-                R.drawable.ic_done_all
+                R.drawable.ic_state_read
             }
         } else {
             if (itemWithFeed.isStarred) {

--- a/app/src/main/res/drawable/ic_remove_done.xml
+++ b/app/src/main/res/drawable/ic_remove_done.xml
@@ -1,5 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M1.79,12l5.58,5.59L5.96,19 0.37,13.41 1.79,12zM2.24,4.22L12.9,14.89l-1.28,1.28L7.44,12l-1.41,1.41L11.62,19l2.69,-2.69 4.89,4.89 1.41,-1.41L3.65,2.81 2.24,4.22zM17.14,13.49L23.62,7 22.2,5.59l-6.48,6.48 1.42,1.42zM17.96,7l-1.41,-1.41 -3.65,3.66 1.41,1.41L17.96,7z"/>
-    
-</vector>

--- a/app/src/main/res/drawable/ic_state_read.xml
+++ b/app/src/main/res/drawable/ic_state_read.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="m480,40 l362,216q18,11 28,30t10,40v434q0,33 -23.5,56.5T800,840L160,840q-33,0 -56.5,-23.5T80,760v-434q0,-21 10,-40t28,-30l362,-216ZM480,506 L792,320 480,134 168,320 480,506ZM480,600L160,408v352h640v-352L480,600ZM480,760h320,-640 320Z"
+  />
+</vector>

--- a/app/src/main/res/drawable/ic_state_unread.xml
+++ b/app/src/main/res/drawable/ic_state_unread.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M22,6c0,-1.1 -0.9,-2 -2,-2L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6zM20,6l-8,5 -8,-5h16zM20,18L4,18L4,8l8,5 8,-5v10z"
+    />
+</vector>


### PR DESCRIPTION
Ok, this one will probably be a bit controversial but I find the icons to mark as read and unread in the `ItemScreenBottomBar` confusing. This PR adopts the icons used by FreshRSS that are IMHO more expressive.

![Screenshot_20250201_133009](https://github.com/user-attachments/assets/1dfadf96-2595-41c5-bdbb-68a71a77fb1c)
![Screenshot_20250201_133018](https://github.com/user-attachments/assets/7c89e278-93ce-486d-ad8e-d1d38d572574)

