### PR TITLE
Simplify read and unread feed query

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,17 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     kotlin("android")
     alias(libs.plugins.compose.compiler)
     id("com.mikepenz.aboutlibraries.plugin")
+}
+
+val props = Properties().apply {
+    runCatching {
+        load(FileInputStream(rootProject.file("local.properties")))
+    }
 }
 
 
@@ -21,7 +30,10 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
 
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
 
         debug {
@@ -40,6 +52,21 @@ android {
 
             applicationIdSuffix = ".beta"
             signingConfig = signingConfigs.getByName("debug")
+        }
+
+        configureEach {
+            val shouldSource = name == "debug" || name == "beta"
+            listOf(
+                "url" to "https://",
+                "login" to "",
+                "password" to ""
+            ).forEach { (k, v) ->
+                resValue(
+                    "string",
+                    "debug.${k}",
+                    if (shouldSource) props.getProperty("debug.$k", v) else v
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/readrops/app/AppModule.kt
+++ b/app/src/main/java/com/readrops/app/AppModule.kt
@@ -1,6 +1,7 @@
 package com.readrops.app
 
 import android.content.Context
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.NotificationManagerCompat
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.SharedPreferencesMigration
@@ -64,7 +65,7 @@ val appModule = module {
     }
 
     factory { (accountType: Account, mode: AccountCredentialsScreenMode) ->
-        AccountCredentialsScreenModel(accountType, mode, get())
+        AccountCredentialsScreenModel(accountType, mode, get(), context = get())
     }
 
     factory { (account: Account) -> NotificationsScreenModel(account, get(), get(), get()) }

--- a/app/src/main/java/com/readrops/app/account/credentials/AccountCredentialsScreenModel.kt
+++ b/app/src/main/java/com/readrops/app/account/credentials/AccountCredentialsScreenModel.kt
@@ -1,5 +1,6 @@
 package com.readrops.app.account.credentials
 
+import android.content.Context
 import android.content.SharedPreferences
 import android.util.Patterns
 import cafe.adriel.voyager.core.model.StateScreenModel
@@ -16,14 +17,22 @@ import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.parameter.parametersOf
+import com.readrops.app.R
+
 
 class AccountCredentialsScreenModel(
     private val account: Account,
     private val mode: AccountCredentialsScreenMode,
     private val database: Database,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
-) : StateScreenModel<AccountCredentialsState>(AccountCredentialsState()), KoinComponent {
-
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    context: Context,
+) : StateScreenModel<AccountCredentialsState>(
+    AccountCredentialsState(
+        url = context.getString(R.string.debug_url),
+        login = context.getString(R.string.debug_login),
+        password = context.getString(R.string.debug_password),
+    )
+), KoinComponent {
     init {
         if (mode == AccountCredentialsScreenMode.EDIT_CREDENTIALS) {
             mutableState.update {
@@ -35,7 +44,9 @@ class AccountCredentialsScreenModel(
                 )
             }
         } else {
-            mutableState.update { it.copy(name = account.name!!) }
+            mutableState.update {
+                it.copy(name = account.name!!)
+            }
         }
     }
 

--- a/app/src/main/java/com/readrops/app/timelime/TimelineScreenModel.kt
+++ b/app/src/main/java/com/readrops/app/timelime/TimelineScreenModel.kt
@@ -2,6 +2,7 @@ package com.readrops.app.timelime
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.compose.runtime.Stable
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
@@ -101,17 +102,17 @@ class TimelineScreenModel(
 
                 preferences.hideReadFeeds.flow
                     .flatMapLatest { hideReadFeeds ->
-                        getFoldersWithFeeds.get(
+                        getFoldersWithFeeds.get2(
                             accountId = account.id,
                             mainFilter = filters.mainFilter,
-                            useSeparateState = account.config.useSeparateState,
                             hideReadFeeds = hideReadFeeds
                         )
                     }
                     .collect { foldersAndFeeds ->
                         _timelineState.update {
                             it.copy(
-                                foldersAndFeeds = foldersAndFeeds
+                                unreadNewItemsCount = foldersAndFeeds.totalUnreadCount,
+                                foldersAndFeeds = foldersAndFeeds.foldersAndFeeds
                             )
                         }
                     }

--- a/db/schemas/com.readrops.db.Database/6.json
+++ b/db/schemas/com.readrops.db.Database/6.json
@@ -1,0 +1,550 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "6ddc8ac26c45b066cb641af8fe567f06",
+    "entities": [
+      {
+        "tableName": "Feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `description` TEXT, `url` TEXT, `image_url` TEXT, `siteUrl` TEXT, `last_updated` TEXT, `color` INTEGER NOT NULL, `icon_url` TEXT, `etag` TEXT, `last_modified` TEXT, `folder_id` INTEGER, `remote_id` TEXT, `account_id` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL DEFAULT 1, `open_in` TEXT NOT NULL, `open_in_ask` INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(`folder_id`) REFERENCES `Folder`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`account_id`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "siteUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNotificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "openIn",
+            "columnName": "open_in",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openInAsk",
+            "columnName": "open_in_ask",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Feed_folder_id",
+            "unique": false,
+            "columnNames": [
+              "folder_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Feed_folder_id` ON `${TABLE_NAME}` (`folder_id`)"
+          },
+          {
+            "name": "index_Feed_account_id",
+            "unique": false,
+            "columnNames": [
+              "account_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Feed_account_id` ON `${TABLE_NAME}` (`account_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Folder",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "folder_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "account_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT, `description` TEXT, `clean_description` TEXT, `link` TEXT, `image_link` TEXT, `author` TEXT, `pub_date` INTEGER, `content` TEXT, `feed_id` INTEGER NOT NULL, `read_time` REAL NOT NULL, `read` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `remote_id` TEXT, FOREIGN KEY(`feed_id`) REFERENCES `Feed`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanDescription",
+            "columnName": "clean_description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageLink",
+            "columnName": "image_link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pubDate",
+            "columnName": "pub_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feed_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readTime",
+            "columnName": "read_time",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Item_feed_id",
+            "unique": false,
+            "columnNames": [
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Item_feed_id` ON `${TABLE_NAME}` (`feed_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feed_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Folder",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `remoteId` TEXT, `account_id` INTEGER NOT NULL, FOREIGN KEY(`account_id`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Folder_account_id",
+            "unique": false,
+            "columnNames": [
+              "account_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Folder_account_id` ON `${TABLE_NAME}` (`account_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "account_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `name` TEXT, `displayed_name` TEXT, `type` TEXT, `last_modified` INTEGER NOT NULL, `current_account` INTEGER NOT NULL, `token` TEXT, `write_token` TEXT, `notifications_enabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "displayedName",
+            "columnName": "displayed_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCurrentAccount",
+            "columnName": "current_account",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "writeToken",
+            "columnName": "write_token",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isNotificationsEnabled",
+            "columnName": "notifications_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ItemStateChange",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `read_change` INTEGER NOT NULL, `star_change` INTEGER NOT NULL, `account_id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`account_id`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readChange",
+            "columnName": "read_change",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starChange",
+            "columnName": "star_change",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "account_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ItemState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `read` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `remote_id` TEXT NOT NULL, `account_id` INTEGER NOT NULL, FOREIGN KEY(`account_id`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ItemState_remote_id_account_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id",
+              "account_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ItemState_remote_id_account_id` ON `${TABLE_NAME}` (`remote_id`, `account_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "account_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "FeedAndUnreadCount",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT \n        Account.id as accountId,\n        Feed.*,\n        CASE\n            WHEN Account.type = 'GREADER' OR Account.type = 'FRESHRSS' \n                THEN sum(iif(not ItemState.read, 1, 0))\n            ELSE sum(iif(not Item.read, 1, 0))\n        END\n        AS unreadCount\n    FROM Account \n    LEFT JOIN Feed ON Feed.account_id = Account.id\n    LEFT JOIN Item ON Item.feed_id = Feed.id\n    LEFT JOIN ItemState ON Item.remote_id = ItemState.remote_id\n    GROUP BY Feed.id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6ddc8ac26c45b066cb641af8fe567f06')"
+    ]
+  }
+}

--- a/db/src/main/java/com/readrops/db/Database.kt
+++ b/db/src/main/java/com/readrops/db/Database.kt
@@ -1,5 +1,6 @@
 package com.readrops.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
@@ -12,6 +13,7 @@ import com.readrops.db.dao.ItemDao
 import com.readrops.db.dao.ItemStateChangeDao
 import com.readrops.db.dao.ItemStateDao
 import com.readrops.db.entities.Feed
+import com.readrops.db.entities.FeedAndUnreadCount
 import com.readrops.db.entities.Folder
 import com.readrops.db.entities.Item
 import com.readrops.db.entities.ItemState
@@ -23,7 +25,9 @@ import com.readrops.db.util.Converters
 @Database(
     entities = [Feed::class, Item::class, Folder::class, Account::class,
         ItemStateChange::class, ItemState::class],
-    version = 5
+    views = [FeedAndUnreadCount::class],
+    version = 6,
+    autoMigrations = [AutoMigration(5, 6)]
 )
 @TypeConverters(Converters::class)
 abstract class Database : RoomDatabase() {

--- a/db/src/main/java/com/readrops/db/dao/FeedDao.kt
+++ b/db/src/main/java/com/readrops/db/dao/FeedDao.kt
@@ -6,6 +6,7 @@ import androidx.room.RawQuery
 import androidx.room.Transaction
 import androidx.sqlite.db.SupportSQLiteQuery
 import com.readrops.db.entities.Feed
+import com.readrops.db.entities.FeedAndUnreadCount
 import com.readrops.db.entities.Item
 import com.readrops.db.entities.OpenIn
 import com.readrops.db.entities.account.Account
@@ -79,6 +80,9 @@ interface FeedDao : BaseDao<Feed> {
 
     @Query("Update Feed set open_in_ask = :openInAsk Where id = :feedId")
     suspend fun updateOpenInAsk(feedId: Int, openInAsk: Boolean)
+
+    @Query("Select * from FeedAndUnreadCount Where FeedAndUnreadCount.account_id = :accountId")
+    suspend fun feedAndUnreadCount(accountId: Int): List<FeedAndUnreadCount>
 
     /**
      * Insert, update and delete feeds by account

--- a/db/src/main/java/com/readrops/db/dao/FolderDao.kt
+++ b/db/src/main/java/com/readrops/db/dao/FolderDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Transaction
 import androidx.sqlite.db.SupportSQLiteQuery
 import com.readrops.db.entities.Feed
 import com.readrops.db.entities.Folder
+import com.readrops.db.entities.FolderWithFeedAndUnreadCount
 import com.readrops.db.entities.Item
 import com.readrops.db.entities.account.Account
 import com.readrops.db.pojo.FolderWithFeed
@@ -18,6 +19,14 @@ interface FolderDao : BaseDao<Folder> {
     // TODO react to Item changes when this table is not part of the query might be a perf issue
     @RawQuery(observedEntities = [Folder::class, Feed::class, Item::class])
     fun selectFoldersAndFeeds(query: SupportSQLiteQuery): Flow<List<FolderWithFeed>>
+
+    @Transaction
+    @Query("""
+        SELECT FeedAndUnreadCount.*, Folder.* FROM FeedAndUnreadCount 
+        LEFT JOIN Folder ON FeedAndUnreadCount.folder_id = Folder.id
+        WHERE FeedAndUnreadCount.accountId = :accountId
+    """)
+    fun selectFolders2(accountId: Int): Flow<List<FolderWithFeedAndUnreadCount>>
 
     @Query("Select * From Folder Where account_id = :accountId")
     fun selectFolders(accountId: Int): Flow<List<Folder>>

--- a/db/src/main/java/com/readrops/db/entities/Feed.kt
+++ b/db/src/main/java/com/readrops/db/entities/Feed.kt
@@ -2,6 +2,8 @@ package com.readrops.db.entities
 
 import androidx.annotation.ColorInt
 import androidx.room.ColumnInfo
+import androidx.room.DatabaseView
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Ignore
@@ -51,4 +53,26 @@ data class Feed(
     @ColumnInfo(name = "open_in_ask", defaultValue = "1") var openInAsk: Boolean = true,
     @Ignore var unreadCount: Int = 0,
     @Ignore var remoteFolderId: String? = null,
+)
+
+@DatabaseView("""
+    SELECT 
+        Account.id as accountId,
+        Feed.*,
+        CASE
+            WHEN Account.type = 'GREADER' OR Account.type = 'FRESHRSS' 
+                THEN sum(iif(not ItemState.read, 1, 0))
+            ELSE sum(iif(not Item.read, 1, 0))
+        END
+        AS unreadCount
+    FROM Account 
+    LEFT JOIN Feed ON Feed.account_id = Account.id
+    LEFT JOIN Item ON Item.feed_id = Feed.id
+    LEFT JOIN ItemState ON Item.remote_id = ItemState.remote_id
+    GROUP BY Feed.id
+""")
+data class FeedAndUnreadCount(
+    val accountId: Int,
+    val unreadCount: Int = 0,
+    @Embedded val feed: Feed
 )

--- a/db/src/main/java/com/readrops/db/entities/Folder.kt
+++ b/db/src/main/java/com/readrops/db/entities/Folder.kt
@@ -1,9 +1,12 @@
 package com.readrops.db.entities
 
 import androidx.room.ColumnInfo
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import androidx.room.Relation
 import com.readrops.db.entities.account.Account
 
 @Entity(
@@ -17,7 +20,36 @@ data class Folder(
     var name: String? = null,
     var remoteId: String? = null,
     @ColumnInfo(name = "account_id", index = true) var accountId: Int = 0,
+    @Ignore var unreadCount: Int = 0,
 ) : Comparable<Folder> {
 
     override fun compareTo(other: Folder): Int = this.name!!.compareTo(other.name!!)
 }
+
+data class FolderWithFeedAndUnreadCount(
+    @Embedded val folder: Folder?,
+    @Relation(parentColumn = "id", entityColumn = "folder_id")
+    val feeds: List<FeedAndUnreadCount>
+)
+
+fun List<FolderWithFeedAndUnreadCount>.unbox(): FoldersWithFeedAndUnreadCount {
+    var totalUnreadCount = 0
+    val resultFoldersAndFeeds = this.associate { folderAndFeeds ->
+        var unreadCount = 0
+        val resultFeeds = folderAndFeeds.feeds.map {
+            unreadCount += it.unreadCount
+            totalUnreadCount += it.unreadCount
+            it.feed.copy(unreadCount = it.unreadCount)
+        }
+        folderAndFeeds.folder?.copy(unreadCount = unreadCount) to resultFeeds
+    }
+    return FoldersWithFeedAndUnreadCount(
+        totalUnreadCount = totalUnreadCount,
+        foldersAndFeeds = resultFoldersAndFeeds
+    )
+}
+
+data class FoldersWithFeedAndUnreadCount(
+    val totalUnreadCount: Int,
+    val foldersAndFeeds: Map<Folder?, List<Feed>>
+)


### PR DESCRIPTION
So this is my proposition to solve #262 and part of #255 (where drawer only display feeds with unread items when the filter is on) and would eliminate the need for `FoldersAndFeedsQueryBuilder` and possibly `ItemSelectionQueryBuilder`. It still needs discussion though. @Shinokuni I would love to get your input here. Since this concerns sensitive parts of the app, I may need help to get this PR to completion.