### PR TITLE
Add mecanism to deduce feeds location in special cases

### DIFF
--- a/api/src/main/java/com/readrops/api/utils/ApiUtils.kt
+++ b/api/src/main/java/com/readrops/api/utils/ApiUtils.kt
@@ -1,5 +1,6 @@
 package com.readrops.api.utils
 
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType
 import org.jsoup.Jsoup
 import java.math.BigInteger
@@ -48,5 +49,19 @@ object ApiUtils {
                 .digest(value.toByteArray())
 
         return BigInteger(1, bytes).toString(16)
+    }
+
+    fun handleRssSpecialCases(url: String): String {
+        val uri = url.toHttpUrlOrNull() ?: return url
+
+        val domain = uri.host.split(".").let { it.getOrNull(it.size - 2) }
+
+        if (domain == "youtube" || uri.host.endsWith("youtu.be")) {
+            return uri.queryParameter("list")?.let {
+                "https://www.youtube.com/feeds/videos.xml?playlist_id=$it"
+            } ?: url
+        }
+
+        return url
     }
 }

--- a/api/src/test/java/com/readrops/api/utils/ApiUtilsTest.kt
+++ b/api/src/test/java/com/readrops/api/utils/ApiUtilsTest.kt
@@ -29,4 +29,22 @@ class ApiUtilsTest {
 
         assertEquals(value, "98f6bcd4621d373cade4e832627b4f6")
     }
+
+    @Test
+    fun handleRssSpecialCases() {
+        assertEquals("https://example.com", ApiUtils.handleRssSpecialCases("https://example.com"))
+        assertEquals(
+            "https://www.youtube.com/@user",
+            ApiUtils.handleRssSpecialCases("https://www.youtube.com/@user")
+        )
+        val playlistId = "qog2gifixwn3vitjneusb9xl"
+        assertEquals(
+            "https://www.youtube.com/feeds/videos.xml?playlist_id=$playlistId",
+            ApiUtils.handleRssSpecialCases("https://www.youtube.com/watch?v=qjshdbmlk&list=$playlistId")
+        )
+        assertEquals(
+            "https://www.youtube.com/feeds/videos.xml?playlist_id=$playlistId",
+            ApiUtils.handleRssSpecialCases("https://youtu.be/watch?v=qjshdbmlk&list=$playlistId")
+        )
+    }
 }

--- a/app/src/main/java/com/readrops/app/feeds/newfeed/NewFeedScreen.kt
+++ b/app/src/main/java/com/readrops/app/feeds/newfeed/NewFeedScreen.kt
@@ -89,12 +89,12 @@ class NewFeedScreen(val url: String? = null) : AndroidScreen() {
                     .fillMaxSize(),
             ) {
                 OutlinedTextField(
-                    value = state.url,
+                    value = state.actualUrl,
                     label = { Text(text = stringResource(R.string.enter_url)) },
                     onValueChange = { screenModel.updateUrl(it) },
                     singleLine = true,
                     trailingIcon = {
-                        if (state.url.isNotEmpty()) {
+                        if (state.actualUrl.isNotEmpty()) {
                             IconButton(
                                 onClick = { screenModel.updateUrl("") }
                             ) {


### PR DESCRIPTION
First known special case is Youtube playlists for which RSS feed exists but is not published in a `<link>`.