### PR TITLE
Prevent ShareIntentTextRenderer from escaping chars from HTML

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,10 @@ android {
     lint {
         abortOnError = false
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/readrops/app/util/ShareIntentTextRenderer.kt
+++ b/app/src/main/java/com/readrops/app/util/ShareIntentTextRenderer.kt
@@ -126,6 +126,7 @@ class ShareIntentTextRenderer(private val itemWithFeed: ItemWithFeed): KoinCompo
                 override fun getFilters(): Map<String, Filter> = this@Companion.filters
             })
             .newLineTrimming(false)
+            .autoEscaping(false)
             .build()
     }
 }

--- a/app/src/test/java/com/readrops/app/TemplateTest.kt
+++ b/app/src/test/java/com/readrops/app/TemplateTest.kt
@@ -2,6 +2,10 @@ package com.readrops.app
 
 import com.readrops.app.util.FrenchTypography
 import com.readrops.app.util.RemoveAuthorFilter
+import com.readrops.app.util.ShareIntentTextRenderer
+import com.readrops.db.entities.Item
+import com.readrops.db.entities.OpenIn
+import com.readrops.db.pojo.ItemWithFeed
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -32,5 +36,23 @@ class TemplateTest {
         assertEquals(" !?", FrenchTypography.filter("   !?"))
         assertEquals(" :", FrenchTypography.filter("  :"))
         assertEquals(" ;", FrenchTypography.filter("  ;"))
+    }
+
+    /** Asserts rendered won't HTML escape */
+    @Test
+    fun dontEscape() {
+        val renderer = ShareIntentTextRenderer(
+            ItemWithFeed(
+                Item(title = "\"Title\""),
+                "",
+                0,
+                0,
+                null,
+                null,
+                null,
+                openIn = OpenIn.EXTERNAL_VIEW
+            )
+        )
+        assertEquals("\"Title\"", renderer.render("{{ title }}"))
     }
 }


### PR DESCRIPTION
Small fix that I missed: the template engine is escaping characters for HTML. We don't want that behavior here.