### PR TITLE
Fix feeds at the bottom of the drawer unclickable on long lists

### DIFF
--- a/app/src/main/java/com/readrops/app/timelime/drawer/TimelineDrawer.kt
+++ b/app/src/main/java/com/readrops/app/timelime/drawer/TimelineDrawer.kt
@@ -82,22 +82,27 @@ fun TimelineDrawerContent(
 ) {
     val scrollState = rememberScrollState()
 
-    ModalDrawerSheet(
-        modifier = Modifier
-            .fillMaxHeight()
-            .verticalScroll(scrollState)
-    ) {
-        Spacer(modifier = Modifier.size(MaterialTheme.spacing.drawerSpacing))
+    ModalDrawerSheet {
+        /*
+         * DO NOT REMOVE THIS LAYER!
+         * ModalDrawerSheet seems to have a problem with Modifier.verticalScroll
+         * causing some items at the bottom to be unclickable with long item lists.
+         */
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .verticalScroll(scrollState)
+        ){
+            Spacer(modifier = Modifier.size(MaterialTheme.spacing.drawerSpacing))
 
-        DrawerDefaultItems(
-            selectedItem = state.filters.mainFilter,
-            unreadNewItemsCount = state.unreadNewItemsCount,
-            onClick = { onClickDefaultItem(it) }
-        )
+            DrawerDefaultItems(
+                selectedItem = state.filters.mainFilter,
+                unreadNewItemsCount = state.unreadNewItemsCount,
+                onClick = { onClickDefaultItem(it) }
+            )
 
-        DrawerDivider()
+            DrawerDivider()
 
-        Column {
             for (folderEntry in state.foldersAndFeeds) {
                 val folder = folderEntry.key
 
@@ -153,6 +158,8 @@ fun TimelineDrawerContent(
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.size(MaterialTheme.spacing.drawerSpacing))
         }
     }
 }


### PR DESCRIPTION
When the drawer displays a folder with 70+ feeds, the feed at the bottom are unclickable. This PR fixes this.