### PR TITLE
Fetch as many items as possible during the initial sync

### DIFF
--- a/api/src/main/java/com/readrops/api/services/greader/GReaderDataSource.kt
+++ b/api/src/main/java/com/readrops/api/services/greader/GReaderDataSource.kt
@@ -45,11 +45,11 @@ class GReaderDataSource(private val service: GReaderService) {
                     async { folders = getFolders() },
                     async { feeds = getFeeds() },
                     async {
-                        items = getItems(listOf(GOOGLE_READ, GOOGLE_STARRED), MAX_ITEMS, null)
+                        items = getItems(listOf(GOOGLE_READ, GOOGLE_STARRED), Int.MAX_VALUE, null)
                     },
-                    async { starredItems = getStarredItems(MAX_STARRED_ITEMS) },
-                    async { unreadIds = getItemsIds(GOOGLE_READ, GOOGLE_READING_LIST, MAX_ITEMS) },
-                    async { starredIds = getItemsIds(null, GOOGLE_STARRED, MAX_STARRED_ITEMS) }
+                    async { starredItems = getStarredItems(Int.MAX_VALUE) },
+                    async { unreadIds = getItemsIds(GOOGLE_READ, GOOGLE_READING_LIST, Int.MAX_VALUE) },
+                    async { starredIds = getItemsIds(null, GOOGLE_STARRED, Int.MAX_VALUE) }
                 )
 
             }


### PR DESCRIPTION
I remember encountering this issue when working on [FreshRSS Android](https://github.com/christophehenry/freshrss-android): the `n` query param for `reading-list` endpoint limits the number of item that can be retreived and it defaults to a stupidely low value ([20](https://github.com/FreshRSS/FreshRSS/blob/edge/p/api/greader.php#L1048)) when unset. This will prevent fetching items from feed that heven't published for some time. This is a problem for initial fetching since these feed will always appear empty. There's currently no way to force fetch those older items. Setting the `n` query parameter to a high value during initial fetch mitigates this issue. It doesn't resolve though, since there's still a chance that a server has more than 2 147 483 647 (which is the value of `Int.MAX_VALUE` on Android) items. I think there's some paging mecanism on this endpoint but I don't remember where it's documented.

Note: IMHO `MAX_ITEMS` and `MAX_STARRED_ITEMS` should be replaced by `Int.MAX_VALUE` everywhere even when not doing initial fetch because the problem also risks to reproduce in the case where Readrops has performed an initial sync but hasen't synced in a sufficiently long time that the number of new items to process is higher than `MAX_ITEMS` or `MAX_STARRED_ITEMS`. And this case, howerver unlikely, will be very tricky to debug. The `ot` query parameter is already there to limit the number of results. I don"t think it is a good idea to limit it again with `n`. At least not until `TimelineTab` has a bottom pull-to-refresh feature that force fetching older items.

This should solve #282